### PR TITLE
Add int32 rules

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:protobuf],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/validate.pb.ex
+++ b/lib/validate.pb.ex
@@ -11,9 +11,28 @@ defmodule Validate.FieldRules do
   oneof :type, 0
 
   field :message, 17, optional: true, type: Validate.MessageRules
+  field :int32, 3, optional: true, type: Validate.Int32Rules, oneof: 0
   field :uint64, 6, optional: true, type: Validate.UInt64Rules, oneof: 0
   field :string, 14, optional: true, type: Validate.StringRules, oneof: 0
   field :repeated, 18, optional: true, type: Validate.RepeatedRules, oneof: 0
+end
+
+defmodule Validate.Int32Rules do
+  @moduledoc false
+  use Protobuf, syntax: :proto2
+
+  @type t :: %__MODULE__{
+          lt: integer,
+          lte: integer,
+          gt: integer,
+          gte: integer
+        }
+  defstruct [:lt, :lte, :gt, :gte]
+
+  field :lt, 2, optional: true, type: :int32
+  field :lte, 3, optional: true, type: :int32
+  field :gt, 4, optional: true, type: :int32
+  field :gte, 5, optional: true, type: :int32
 end
 
 defmodule Validate.MessageRules do
@@ -34,12 +53,16 @@ defmodule Validate.UInt64Rules do
 
   @type t :: %__MODULE__{
           lt: non_neg_integer,
-          gt: non_neg_integer
+          lte: non_neg_integer,
+          gt: non_neg_integer,
+          gte: non_neg_integer
         }
-  defstruct [:lt, :gt]
+  defstruct [:lt, :lte, :gt, :gte]
 
   field :lt, 2, optional: true, type: :uint64
+  field :lte, 3, optional: true, type: :uint64
   field :gt, 4, optional: true, type: :uint64
+  field :gte, 5, optional: true, type: :uint64
 end
 
 defmodule Validate.StringRules do

--- a/lib/validator/vex.ex
+++ b/lib/validator/vex.ex
@@ -89,8 +89,18 @@ defmodule ProtoValidator.Validator.Vex do
     {Vex.Validators.Number, [greater_than: v, message: "should greater than #{v}"]}
   end
 
+  defp translate_rule({_, {:gte, v}}) do
+    {Vex.Validators.Number,
+     [greater_than_or_equal_to: v, message: "should greater than or equal to #{v}"]}
+  end
+
   defp translate_rule({_, {:lt, v}}) do
     {Vex.Validators.Number, [less_than: v, message: "should less than #{v}"]}
+  end
+
+  defp translate_rule({_, {:lte, v}}) do
+    {Vex.Validators.Number,
+     [less_than_or_equal_to: v, message: "should less than or equal to #{v}"]}
   end
 
   defp translate_rule({_, {:min_len, v}}) do

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ProtoValidator.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:protobuf, "~> 0.8.0-beta.1"},
+      {:protobuf, "== 0.8.0-beta.1"},
       {:vex, "~> 0.8.0"}
     ]
   end

--- a/src/validate.proto
+++ b/src/validate.proto
@@ -60,11 +60,11 @@ message RepeatedRules {
     optional uint64 max_items = 2;
 
     // Unique specifies that all elements in this field must be unique. This
-    // contraint is only applicable to scalar and enum types (messages are not
+    // constraint is only applicable to scalar and enum types (messages are not
     // supported).
     optional bool   unique    = 3;
 
-    // Items specifies the contraints to be applied to each item in the field.
+    // Items specifies the constraints to be applied to each item in the field.
     // Repeated message fields will still execute validation against each item
     // unless skip is specified here.
     optional FieldRules items = 4;

--- a/src/validate.proto
+++ b/src/validate.proto
@@ -14,10 +14,32 @@ message FieldRules {
     optional MessageRules message = 17;
     oneof type {
         // Scalar Field Types
+        Int32Rules    int32    = 3;
         UInt64Rules   uint64   = 6;
         StringRules   string   = 14;
         RepeatedRules repeated = 18;
     }
+}
+
+// Int32Rules describes the constraints applied to `int32` values
+message Int32Rules {
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int32 gte = 5;
 }
 
 message MessageRules {
@@ -30,10 +52,20 @@ message UInt64Rules {
     // Lt specifies that this field must be less than the specified value,
     // exclusive
     optional uint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint64 lte = 3;
+
     // Gt specifies that this field must be greater than the specified value,
     // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
     // range is reversed.
     optional uint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint64 gte = 5;
 }
 
 // StringRules describe the constraints applied to `string` values

--- a/test/proto/example.proto
+++ b/test/proto/example.proto
@@ -38,3 +38,9 @@ message User {
     items: {uint64: {gt: 0, lt: 90}}
   }];
 }
+
+message Foo {
+  int32 int32 = 1 [(validate.rules) = {
+    int32: {gte: 0, lte: 10}
+  }];
+}

--- a/test/proto_gen/example.pb.ex
+++ b/test/proto_gen/example.pb.ex
@@ -43,3 +43,16 @@ defmodule Examplepb.User do
   field :phones, 4, repeated: true, type: Examplepb.Phone
   field :following_ids, 5, repeated: true, type: :uint64, json_name: "followingIds"
 end
+
+defmodule Examplepb.Foo do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          int32: integer
+        }
+
+  defstruct [:int32]
+
+  field :int32, 1, type: :int32
+end

--- a/test/proto_gen/example.pb.validate.ex
+++ b/test/proto_gen/example.pb.validate.ex
@@ -19,3 +19,10 @@ defmodule ProtoValidator.Gen.Examplepb.User do
     repeated: [items: [uint64: [gt: 0, lt: 90]], min_items: 0, unique: true]
   )
 end
+
+defmodule ProtoValidator.Gen.Examplepb.Foo do
+  @moduledoc false
+  use ProtoValidator, entity: Examplepb.Foo
+
+  validate(:int32, type: :int32, int32: [gte: 0, lte: 10])
+end

--- a/test/proto_validator_test.exs
+++ b/test/proto_validator_test.exs
@@ -224,4 +224,16 @@ defmodule ProtoValidator.ProtoValidatorTest do
 
     assert {:error, "Invalid email, length must be at least 5"} = ProtoValidator.validate(user)
   end
+
+  test "validate integer gte, lte rules" do
+    assert :ok = ProtoValidator.validate(%Examplepb.Foo{int32: 0})
+
+    assert {:error, "Invalid int32, should greater than or equal to 0"} =
+             ProtoValidator.validate(%Examplepb.Foo{int32: -1})
+
+    assert :ok = ProtoValidator.validate(%Examplepb.Foo{int32: 10})
+
+    assert {:error, "Invalid int32, should less than or equal to 10"} =
+             ProtoValidator.validate(%Examplepb.Foo{int32: 11})
+  end
 end


### PR DESCRIPTION
- Temporary fix, depends on protobuf v0.8.0-beta.1
  - Some difference.  
  - O `use ProtoValidator, entity: Foo.PB.API.SomeMessage` (v0.8.0-beta.1)
  - X `use ProtoValidator, entity: Foo.API.SomeMessage` (v0.8.0)
- Add Int32Rules and UInt64 lte, gte rules
- Tiny fixes